### PR TITLE
bulk mark as paid, filtered PDF download, PDF preview perf, discount fix

### DIFF
--- a/lib/common.dart
+++ b/lib/common.dart
@@ -237,7 +237,6 @@ class SupportedCurrencies {
     CurrencyOption(code: 'GBP', symbol: '£',   name: 'British Pound'),
     CurrencyOption(code: 'JMD', symbol: 'J\$', name: 'Jamaican Dollar'),
     CurrencyOption(code: 'JPY', symbol: '¥',   name: 'Japanese Yen'),
-    CurrencyOption(code: 'OMR', symbol: 'OMR', name: 'Omani Rial'),
     CurrencyOption(code: 'SGD', symbol: 'S\$', name: 'Singapore Dollar'),
     CurrencyOption(code: 'USD', symbol: '\$',  name: 'US Dollar'),
     CurrencyOption(code: 'ZAR', symbol: 'R',   name: 'South African Rand'),

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -64,7 +64,7 @@ class AppBorderRadius
 class AppConfig
 {
   static const name = "invoiso";
-  static const version = "v4.1.3";
+  static const version = "v4.1.4";
   static const developer = "ANOOP P";
   static const supportEmail = "anooppkrishnan96@gmail.com";
   static const website = "https://invoiso.co.in/";
@@ -89,4 +89,5 @@ class DefaultValues
   static const String additionalNote = "No return after 15 days.";
   static const String thankYouNote = "Thank you for your business! | Visit us at [Your Website]";
   static const LogoPosition logoPosition = LogoPosition.left;
+  static const int additionalNotesLength = 1000;
 }

--- a/lib/database/invoice_service.dart
+++ b/lib/database/invoice_service.dart
@@ -252,6 +252,8 @@ class InvoiceService {
   static Future<List<Invoice>> getInvoicesForExport({
     DateTime? fromDate,
     DateTime? toDate,
+    int? fromId,
+    int? toId,
     String? filterType,
   }) async {
     final db = await dbHelper.database;
@@ -270,6 +272,14 @@ class InvoiceService {
       whereParts.add('date <= ?');
       whereArgs.add('${toDate.toIso8601String().substring(0, 10)}T23:59:59.999');
     }
+    if (fromId != null) {
+      whereParts.add('CAST(id AS INTEGER) >= ?');
+      whereArgs.add(fromId);
+    }
+    if (toId != null) {
+      whereParts.add('CAST(id AS INTEGER) <= ?');
+      whereArgs.add(toId);
+    }
 
     final invoiceMaps = await db.query(
       'invoices',
@@ -279,6 +289,46 @@ class InvoiceService {
     );
 
     return _buildInvoiceList(invoiceMaps);
+  }
+
+  // Lightweight COUNT — no object construction, used for filter preview + cap check.
+  static Future<int> countInvoicesForExport({
+    DateTime? fromDate,
+    DateTime? toDate,
+    int? fromId,
+    int? toId,
+    String? filterType,
+  }) async {
+    final db = await dbHelper.database;
+    final whereParts = <String>['deleted_at IS NULL'];
+    final whereArgs = <dynamic>[];
+
+    if (filterType != null && filterType.isNotEmpty) {
+      whereParts.add('type = ?');
+      whereArgs.add(filterType);
+    }
+    if (fromDate != null) {
+      whereParts.add('date >= ?');
+      whereArgs.add('${fromDate.toIso8601String().substring(0, 10)}T00:00:00.000');
+    }
+    if (toDate != null) {
+      whereParts.add('date <= ?');
+      whereArgs.add('${toDate.toIso8601String().substring(0, 10)}T23:59:59.999');
+    }
+    if (fromId != null) {
+      whereParts.add('CAST(id AS INTEGER) >= ?');
+      whereArgs.add(fromId);
+    }
+    if (toId != null) {
+      whereParts.add('CAST(id AS INTEGER) <= ?');
+      whereArgs.add(toId);
+    }
+
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) AS cnt FROM invoices WHERE ${whereParts.join(' AND ')}',
+      whereArgs.isEmpty ? null : whereArgs,
+    );
+    return (result.first['cnt'] as int?) ?? 0;
   }
 
   // ─────────────────────────────────────────────

--- a/lib/database/payment_service.dart
+++ b/lib/database/payment_service.dart
@@ -78,6 +78,62 @@ class PaymentService {
   }
 
   // ─────────────────────────────────────────────
+  // Batch mark-as-paid: single DB transaction for N invoices.
+  // Skips invoices where outstandingBalance <= 0.
+  static Future<int> addPaymentBatch({
+    required List<Invoice> invoices,
+    required DateTime datePaid,
+    String? paymentMethod,
+    String? notes,
+  }) async {
+    final db = await _dbHelper.database;
+    int count = 0;
+    await db.transaction((txn) async {
+      for (final invoice in invoices) {
+        final amountPaid = invoice.outstandingBalance;
+        if (amountPaid <= 0) continue;
+
+        final suffixResult = await txn.rawQuery(
+          'SELECT receipt_number FROM invoice_payments WHERE invoice_id = ?',
+          [invoice.id],
+        );
+        int maxSuffix = 0;
+        for (final row in suffixResult) {
+          final rn = row['receipt_number'] as String;
+          final dashR = rn.lastIndexOf('-R');
+          if (dashR != -1) {
+            final n = int.tryParse(rn.substring(dashR + 2)) ?? 0;
+            if (n > maxSuffix) maxSuffix = n;
+          }
+        }
+
+        final taxAmountPaid = invoice.total > 0
+            ? (amountPaid * (invoice.tax / invoice.total))
+            : 0.0;
+
+        final payment = InvoicePayment(
+          id: _uuid.v4(),
+          invoiceId: invoice.id,
+          invoiceNumber: invoice.id,
+          receiptNumber: '${invoice.id}-R${maxSuffix + 1}',
+          amountPaid: amountPaid,
+          taxAmountPaid: taxAmountPaid,
+          previouslyPaid: invoice.amountPaid,
+          balanceAfter: 0.0,
+          datePaid: datePaid,
+          paymentMethod: paymentMethod,
+          notes: notes,
+        );
+
+        await txn.insert('invoice_payments', payment.toMap());
+        count++;
+      }
+    });
+    AppLogger.d(_tag, 'Batch payment: $count invoice(s) marked as paid.');
+    return count;
+  }
+
+  // ─────────────────────────────────────────────
   // Fetch all payments for an invoice, oldest first
   static Future<List<InvoicePayment>> getPaymentsForInvoice(
       String invoiceId) async {

--- a/lib/screens/create_invoice_screen.dart
+++ b/lib/screens/create_invoice_screen.dart
@@ -2442,6 +2442,7 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                       flex: _upiEntries.isNotEmpty ? 3 : 4,
                       child: TextField(
                         controller: notesController,
+                        maxLength: DefaultValues.additionalNotesLength,
                         decoration: InputDecoration(
                           labelText: 'Notes (Optional)',
                           border: OutlineInputBorder(borderRadius: BorderRadius.circular(AppBorderRadius.xsmall)),

--- a/lib/screens/invoice_management_screen.dart
+++ b/lib/screens/invoice_management_screen.dart
@@ -20,6 +20,7 @@ import 'package:invoiso/models/user.dart';
 import 'package:invoiso/widgets/customer_info_button.dart';
 import 'package:invoiso/utils/formatters.dart';
 import 'package:invoiso/database/settings_service.dart';
+import 'package:invoiso/database/payment_service.dart';
 
 class InvoiceManagementScreen extends ConsumerStatefulWidget {
   final Function(Invoice) onEditInvoice;
@@ -622,6 +623,290 @@ class _InvoiceManagementScreenState
     }
   }
 
+  static const int _maxBulkPdfExport = 100;
+
+  Future<void> _showFilteredDownloadDialog() async {
+    DateTime? fromDate;
+    DateTime? toDate;
+    final fromIdCtrl = TextEditingController();
+    final toIdCtrl   = TextEditingController();
+    int filterMode   = 0; // 0 = date, 1 = invoice number
+    int matchCount   = 0;
+    bool counting    = false;
+
+    Future<int> fetchCount(StateSetter setS) async {
+      setS(() => counting = true);
+      try {
+        return await InvoiceService.countInvoicesForExport(
+          fromDate: filterMode == 0 ? fromDate : null,
+          toDate:   filterMode == 0 ? toDate   : null,
+          fromId:   filterMode == 1 ? int.tryParse(fromIdCtrl.text) : null,
+          toId:     filterMode == 1 ? int.tryParse(toIdCtrl.text)   : null,
+          filterType: widget.filterType,
+        );
+      } finally {
+        setS(() => counting = false);
+      }
+    }
+
+    await showDialog(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setS) => AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          title: const Row(
+            children: [
+              Icon(Icons.filter_alt_outlined),
+              SizedBox(width: 10),
+              Text('Download PDFs by Filter'),
+            ],
+          ),
+          content: SizedBox(
+            width: 420,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SegmentedButton<int>(
+                  segments: const [
+                    ButtonSegment(value: 0, label: Text('By Date'),           icon: Icon(Icons.calendar_today_outlined, size: 16)),
+                    ButtonSegment(value: 1, label: Text('By Invoice Number'), icon: Icon(Icons.tag_outlined, size: 16)),
+                  ],
+                  selected: {filterMode},
+                  onSelectionChanged: (v) async {
+                    setS(() { filterMode = v.first; matchCount = 0; });
+                  },
+                ),
+                const SizedBox(height: 16),
+                if (filterMode == 0) ...[
+                  Row(children: [
+                    Expanded(child: _DatePickerField(
+                      label: 'From date',
+                      value: fromDate,
+                      formatter: DateFormat('dd/MM/yyyy'),
+                      onPicked: (d) { setS(() { fromDate = d; matchCount = 0; }); },
+                      onCleared: () => setS(() { fromDate = null; matchCount = 0; }),
+                    )),
+                    const SizedBox(width: 12),
+                    Expanded(child: _DatePickerField(
+                      label: 'To date',
+                      value: toDate,
+                      formatter: DateFormat('dd/MM/yyyy'),
+                      onPicked: (d) { setS(() { toDate = d; matchCount = 0; }); },
+                      onCleared: () => setS(() { toDate = null; matchCount = 0; }),
+                    )),
+                  ]),
+                ] else ...[
+                  Row(children: [
+                    Expanded(child: TextField(
+                      controller: fromIdCtrl,
+                      keyboardType: TextInputType.number,
+                      decoration: const InputDecoration(labelText: 'From invoice #', border: OutlineInputBorder()),
+                      onChanged: (_) => setS(() => matchCount = 0),
+                    )),
+                    const SizedBox(width: 12),
+                    Expanded(child: TextField(
+                      controller: toIdCtrl,
+                      keyboardType: TextInputType.number,
+                      decoration: const InputDecoration(labelText: 'To invoice #', border: OutlineInputBorder()),
+                      onChanged: (_) => setS(() => matchCount = 0),
+                    )),
+                  ]),
+                ],
+                const SizedBox(height: 16),
+                Row(children: [
+                  FilledButton.tonal(
+                    onPressed: counting ? null : () async {
+                      final c = await fetchCount(setS);
+                      setS(() => matchCount = c);
+                    },
+                    child: counting
+                        ? const SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2))
+                        : const Text('Check count'),
+                  ),
+                  const SizedBox(width: 12),
+                  if (matchCount > 0)
+                    Text(
+                      matchCount > _maxBulkPdfExport
+                          ? '$matchCount invoices — exceeds limit of $_maxBulkPdfExport'
+                          : '$matchCount invoice${matchCount == 1 ? '' : 's'} match',
+                      style: TextStyle(
+                        color: matchCount > _maxBulkPdfExport ? Colors.red : Colors.green[700],
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                ]),
+                if (matchCount > _maxBulkPdfExport)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      'Max $_maxBulkPdfExport PDFs per download. Narrow your filter.',
+                      style: const TextStyle(color: Colors.red, fontSize: 12),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.folder_outlined),
+              label: const Text('Save to Folder'),
+              onPressed: matchCount > 0 && matchCount <= _maxBulkPdfExport
+                  ? () => Navigator.pop(ctx, 'folder')
+                  : null,
+            ),
+            FilledButton.icon(
+              icon: const Icon(Icons.folder_zip_outlined),
+              label: const Text('Save as ZIP'),
+              onPressed: matchCount > 0 && matchCount <= _maxBulkPdfExport
+                  ? () => Navigator.pop(ctx, 'zip')
+                  : null,
+            ),
+          ],
+        ),
+      ),
+    ).then((saveMode) async {
+      if (saveMode == null || !mounted) return;
+
+      final invoices = await InvoiceService.getInvoicesForExport(
+        fromDate:   filterMode == 0 ? fromDate : null,
+        toDate:     filterMode == 0 ? toDate   : null,
+        fromId:     filterMode == 1 ? int.tryParse(fromIdCtrl.text) : null,
+        toId:       filterMode == 1 ? int.tryParse(toIdCtrl.text)   : null,
+        filterType: widget.filterType,
+      );
+
+      if (invoices.isEmpty) {
+        if (mounted) AppError.show(context, 'No invoices found for the selected filter.');
+        return;
+      }
+      if (invoices.length > _maxBulkPdfExport) {
+        if (mounted) AppError.show(context, 'Filter returned ${invoices.length} invoices — max is $_maxBulkPdfExport.');
+        return;
+      }
+
+      String? outputDir;
+      String? zipSavePath;
+      if (saveMode == 'folder') {
+        outputDir = await FilePicker.platform.getDirectoryPath(dialogTitle: 'Choose folder to save PDFs');
+        if (outputDir == null || !mounted) return;
+      } else {
+        zipSavePath = await FilePicker.platform.saveFile(
+          dialogTitle: 'Save ZIP file',
+          fileName: 'invoices_${DateFormat('yyyyMMdd').format(DateTime.now())}.zip',
+          type: FileType.custom,
+          allowedExtensions: ['zip'],
+        );
+        if (zipSavePath == null || !mounted) return;
+      }
+
+      setState(() => _isBulkLoading = true);
+      final progress = ValueNotifier<int>(0);
+
+      unawaited(showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (ctx) => AlertDialog(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          title: Row(children: [
+            Icon(saveMode == 'zip' ? Icons.folder_zip_outlined : Icons.picture_as_pdf, color: Colors.orange),
+            const SizedBox(width: 12),
+            Text(saveMode == 'zip' ? 'Creating ZIP' : 'Generating PDFs'),
+          ]),
+          content: ValueListenableBuilder<int>(
+            valueListenable: progress,
+            builder: (_, done, __) => Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('Processing ${invoices.length} PDF${invoices.length == 1 ? '' : 's'}...'),
+                const SizedBox(height: 16),
+                LinearProgressIndicator(value: done / invoices.length, backgroundColor: Colors.grey[200]),
+                const SizedBox(height: 8),
+                Text('$done / ${invoices.length}', style: TextStyle(color: Colors.grey[600], fontSize: 13)),
+              ],
+            ),
+          ),
+        ),
+      ));
+
+      try {
+        // Fetch PDF settings once for the entire batch.
+        final settings = await PDFService.fetchPdfSettings();
+        final String path;
+        if (saveMode == 'zip') {
+          path = await ExportService.exportInvoicesToZip(
+            invoices, zipSavePath!,
+            onProgress: (done, _) => progress.value = done,
+            settings: settings,
+          );
+        } else {
+          path = await ExportService.exportInvoicesToPdfFolder(
+            invoices,
+            onProgress: (done, _) => progress.value = done,
+            outputDirectory: outputDir,
+            settings: settings,
+          );
+        }
+        if (mounted) {
+          Navigator.of(context, rootNavigator: true).pop();
+          AppError.showSuccess(context, 'Saved to: $path');
+          await OpenFile.open(path);
+        }
+      } catch (e) {
+        if (mounted) {
+          Navigator.of(context, rootNavigator: true).pop();
+          AppError.show(context, 'Export failed: $e');
+        }
+      } finally {
+        progress.dispose();
+        if (mounted) setState(() => _isBulkLoading = false);
+      }
+    });
+
+    fromIdCtrl.dispose();
+    toIdCtrl.dispose();
+  }
+
+  Future<void> _bulkMarkAsPaid() async {
+    final unpaid = _pageInvoices
+        .where((inv) => _selectedIds.contains(inv.id) && inv.outstandingBalance > 0)
+        .toList();
+    final alreadyPaid = _selectedIds.length - unpaid.length;
+
+    if (unpaid.isEmpty) {
+      AppError.show(context, 'All selected invoices are already fully paid.');
+      return;
+    }
+
+    final confirmed = await AppError.confirm(
+      context,
+      title: 'Mark as Paid',
+      message: 'Mark ${unpaid.length} invoice${unpaid.length == 1 ? '' : 's'} as fully paid?'
+          '${alreadyPaid > 0 ? '\n($alreadyPaid already paid — will be skipped)' : ''}',
+      confirmLabel: 'Mark as Paid',
+      confirmColor: Colors.green,
+    );
+    if (!confirmed || !mounted) return;
+
+    setState(() => _isBulkLoading = true);
+    try {
+      final count = await PaymentService.addPaymentBatch(
+        invoices: unpaid,
+        datePaid: DateTime.now(),
+      );
+      ref.read(invoicesProvider.notifier).refresh();
+      await _loadPage();
+      if (mounted) {
+        AppError.showSuccess(context, '$count invoice${count == 1 ? '' : 's'} marked as paid.');
+      }
+    } catch (e) {
+      if (mounted) AppError.show(context, 'Failed to mark as paid: $e');
+    } finally {
+      if (mounted) setState(() => _isBulkLoading = false);
+    }
+  }
+
   // ─── Pagination ────────────────────────────────────────────────────────────
 
   int get _totalPages => (_totalCount / _pageSize).ceil();
@@ -651,6 +936,11 @@ class _InvoiceManagementScreenState
                 ),
               ),
             ),
+          IconButton(
+            icon: const Icon(Icons.download_for_offline_outlined),
+            onPressed: _showFilteredDownloadDialog,
+            tooltip: 'Download PDFs by date or invoice range',
+          ),
           IconButton(
             icon: const Icon(Icons.file_download_outlined),
             onPressed: _exportCsv,
@@ -1113,6 +1403,14 @@ class _InvoiceManagementScreenState
           ),
 
           const Spacer(),
+
+          _buildBulkButton(
+            icon: Icons.payments_outlined,
+            label: 'Mark as Paid',
+            color: Colors.green[300]!,
+            onPressed: _isBulkLoading ? null : _bulkMarkAsPaid,
+          ),
+          const SizedBox(width: 8),
 
           _buildBulkButton(
             icon: Icons.table_chart_outlined,

--- a/lib/screens/invoice_settings_screen.dart
+++ b/lib/screens/invoice_settings_screen.dart
@@ -560,7 +560,7 @@ class _InvoiceSettingsScreenState extends State<InvoiceSettingsScreen> {
                               width: constraints.maxWidth,
                               child: TextField(
                                 controller: additionalInfoController,
-                                maxLength: 300,
+                                maxLength: DefaultValues.additionalNotesLength,
                                 maxLines: 3,
                                 decoration: InputDecoration(
                                   labelText: 'Additional Information',

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import '../database/settings_service.dart';
@@ -77,10 +78,12 @@ class ExportService {
   /// Generates a PDF for each invoice in [invoices], saves them into
   /// [outputDirectory] (or a timestamped subfolder of Documents if null),
   /// and returns the folder path.  [onProgress] is called after each PDF.
+  /// Pass [settings] to skip redundant DB reads when bulk-exporting.
   static Future<String> exportInvoicesToPdfFolder(
     List<Invoice> invoices, {
     void Function(int completed, int total)? onProgress,
     String? outputDirectory,
+    PdfGenerationSettings? settings,
   }) async {
     final Directory exportDir;
     if (outputDirectory != null) {
@@ -92,40 +95,43 @@ class ExportService {
     }
     await exportDir.create(recursive: true);
 
+    final s = settings ?? await PDFService.fetchPdfSettings();
     for (int i = 0; i < invoices.length; i++) {
       final invoice = invoices[i];
-      final pdf = await PDFService.generateInvoicePDF(invoice);
+      final pdf = PDFService.generateInvoicePDFWithSettings(invoice, s);
       final bytes = await pdf.save();
       final filename = PDFService.buildPdfFilename(invoice);
-      final file = File('${exportDir.path}/$filename');
-      await file.writeAsBytes(bytes);
+      await File('${exportDir.path}/$filename').writeAsBytes(bytes);
       onProgress?.call(i + 1, invoices.length);
     }
 
     return exportDir.path;
   }
 
-  /// Generates a PDF for each invoice, bundles them into a single ZIP file
-  /// written to [savePath], and returns that path.
-  /// [onProgress] is called after each PDF is added to the archive.
+  /// Generates a PDF for each invoice, streams them directly into a ZIP file
+  /// at [savePath] — never holds more than one PDF in memory at a time.
+  /// Pass [settings] to skip redundant DB reads when bulk-exporting.
   static Future<String> exportInvoicesToZip(
     List<Invoice> invoices,
     String savePath, {
     void Function(int completed, int total)? onProgress,
+    PdfGenerationSettings? settings,
   }) async {
-    final archive = Archive();
+    final s = settings ?? await PDFService.fetchPdfSettings();
+    final output = OutputFileStream(savePath);
+    final encoder = ZipEncoder()..startEncode(output);
 
     for (int i = 0; i < invoices.length; i++) {
       final invoice = invoices[i];
-      final pdf = await PDFService.generateInvoicePDF(invoice);
+      final pdf = PDFService.generateInvoicePDFWithSettings(invoice, s);
       final bytes = await pdf.save();
       final filename = PDFService.buildPdfFilename(invoice);
-      archive.addFile(ArchiveFile(filename, bytes.length, Uint8List.fromList(bytes)));
+      encoder.add(ArchiveFile(filename, bytes.length, Uint8List.fromList(bytes)));
       onProgress?.call(i + 1, invoices.length);
     }
 
-    final zipBytes = ZipEncoder().encode(archive);
-    await File(savePath).writeAsBytes(zipBytes);
+    encoder.endEncode();
+    await output.close();
     return savePath;
   }
 }

--- a/lib/services/pdf_service.dart
+++ b/lib/services/pdf_service.dart
@@ -20,96 +20,201 @@ import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
 
 import '../common.dart';
 
+/// All per-session settings needed to render a PDF.
+/// Fetch once via [PDFService.fetchPdfSettings], reuse for every invoice in a batch.
+class PdfGenerationSettings {
+  final CompanyInfo? company;
+  final InvoiceTemplate template;
+  final String invoicePrefix;
+  final bool showGst;
+  final bool showQuantity;
+  final bool showDiscount;
+  final bool showTypeTag;
+  final BusinessType businessType;
+  final List<UpiEntry> upiEntries;
+  final String? showQrStr;
+  final bool showBankDetails;
+  final List<BankAccount> bankAccounts;
+  final LogoPosition logoPosition;
+  final double logoSizePx;
+  final Uint8List? logoBytes;
+  final String thankYouNote;
+  final String datePattern;
+
+  const PdfGenerationSettings({
+    required this.company,
+    required this.template,
+    required this.invoicePrefix,
+    required this.showGst,
+    required this.showQuantity,
+    required this.showDiscount,
+    required this.showTypeTag,
+    required this.businessType,
+    required this.upiEntries,
+    required this.showQrStr,
+    required this.showBankDetails,
+    required this.bankAccounts,
+    required this.logoPosition,
+    required this.logoSizePx,
+    required this.logoBytes,
+    required this.thankYouNote,
+    required this.datePattern,
+  });
+}
+
 // PDF Generation Service
 class PDFService {
-  static Future<pw.Document> generateInvoicePDF(Invoice invoice, {String datePattern = 'dd/MM/yyyy'}) async
-  {
-    final pdf = pw.Document();
-    final company = await CompanyInfoService.getCompanyInfo();
-    final selectedTemplate = await SettingsService.getInvoiceTemplate();
-    final currencySymbol = invoice.currencySymbol;
-    final rawPrefix = await SettingsService.getSetting(SettingKey.invoicePrefix) ?? 'INV';
-    final invoicePrefix = rawPrefix.isNotEmpty ? '$rawPrefix-' : '';
-    final showGst = await SettingsService.getShowGstFields();
-    final showQuantity = await SettingsService.getShowQuantity();
-    final showDiscount = await SettingsService.getShowDiscount();
-    final showTypeTag = await SettingsService.getShowTypeTag();
-    final businessType = await SettingsService.getBusinessType();
+  // Logo bytes cache — avoids re-decoding base64 on every preview open.
+  static Uint8List? _logoBytesCache;
+  static String? _logoBase64Cache;
 
-    // UPI QR settings — use the per-invoice UPI ID; fall back to the default
-    // UPI from settings so that invoices created before this feature still
-    // show a QR code when the global toggle is on.
+  static Uint8List? _cachedLogoBytes(String? base64Logo) {
+    if (base64Logo == null || base64Logo.isEmpty) {
+      _logoBytesCache = null;
+      _logoBase64Cache = null;
+      return null;
+    }
+    if (base64Logo == _logoBase64Cache && _logoBytesCache != null) return _logoBytesCache;
+    _logoBase64Cache = base64Logo;
+    _logoBytesCache = base64Decode(base64Logo);
+    return _logoBytesCache;
+  }
+
+  /// Call to invalidate the logo cache when the user changes their logo.
+  static void clearLogoCache() {
+    _logoBytesCache = null;
+    _logoBase64Cache = null;
+  }
+
+  /// Fetch all PDF generation settings in one parallel batch.
+  /// Call once before a bulk export, then pass to [generateInvoicePDFWithSettings].
+  static Future<PdfGenerationSettings> fetchPdfSettings({
+    String datePattern = 'dd/MM/yyyy',
+  }) async {
+    final results = await Future.wait<dynamic>([
+      CompanyInfoService.getCompanyInfo(),                          // 0
+      SettingsService.getInvoiceTemplate(),                         // 1
+      SettingsService.getSetting(SettingKey.invoicePrefix),         // 2
+      SettingsService.getShowGstFields(),                           // 3
+      SettingsService.getShowQuantity(),                            // 4
+      SettingsService.getShowDiscount(),                            // 5
+      SettingsService.getShowTypeTag(),                             // 6
+      SettingsService.getBusinessType(),                            // 7
+      SettingsService.getUpiIds(),                                  // 8
+      SettingsService.getSetting(SettingKey.showUpiQr),             // 9
+      SettingsService.getShowBankDetails(),                         // 10
+      SettingsService.getBankAccounts(),                            // 11
+      SettingsService.getLogoPosition(),                            // 12
+      SettingsService.getLogoSize(),                                // 13
+      SettingsService.getCompanyLogo(),                             // 14
+      SettingsService.getSetting(SettingKey.thankYouNote),          // 15
+    ]);
+
+    final rawPrefix = (results[2] as String?) ?? 'INV';
+    final base64Logo = results[14] as String?;
+
+    return PdfGenerationSettings(
+      company:       results[0]  as CompanyInfo?,
+      template:      results[1]  as InvoiceTemplate,
+      invoicePrefix: rawPrefix.isNotEmpty ? '$rawPrefix-' : '',
+      showGst:       results[3]  as bool,
+      showQuantity:  results[4]  as bool,
+      showDiscount:  results[5]  as bool,
+      showTypeTag:   results[6]  as bool,
+      businessType:  results[7]  as BusinessType,
+      upiEntries:    results[8]  as List<UpiEntry>,
+      showQrStr:     results[9]  as String?,
+      showBankDetails: results[10] as bool,
+      bankAccounts:  results[11] as List<BankAccount>,
+      logoPosition:  results[12] as LogoPosition,
+      logoSizePx:    _logoSizePx(results[13] as String),
+      logoBytes:     _cachedLogoBytes(base64Logo),
+      thankYouNote:  (results[15] as String?) ?? DefaultValues.thankYouNote,
+      datePattern:   datePattern,
+    );
+  }
+
+  /// Build a PDF document using pre-fetched settings — no DB reads.
+  /// Use this in batch exports to avoid redundant settings fetches per invoice.
+  static pw.Document generateInvoicePDFWithSettings(
+    Invoice invoice,
+    PdfGenerationSettings s,
+  ) {
+    final pdf = pw.Document();
+    final currencySymbol = invoice.currencySymbol;
+
     String? effectiveUpiId = invoice.upiId;
     if (effectiveUpiId == null || effectiveUpiId.trim().isEmpty) {
-      final upiEntries = await SettingsService.getUpiIds();
-      final fallback = upiEntries.where((e) => e.isDefault).firstOrNull
-          ?? upiEntries.firstOrNull;
+      final fallback = s.upiEntries.where((e) => e.isDefault).firstOrNull
+          ?? s.upiEntries.firstOrNull;
       effectiveUpiId = fallback?.id;
     } else {
       effectiveUpiId = effectiveUpiId.trim();
     }
-    final showQrStr = await SettingsService.getSetting(SettingKey.showUpiQr);
-    final showUpiQr =
-        showQrStr == 'true' && effectiveUpiId != null && effectiveUpiId.isNotEmpty;
+    final showUpiQr = s.showQrStr == 'true' && effectiveUpiId != null && effectiveUpiId.isNotEmpty;
 
-    // Bank account — resolve from per-invoice ID, fall back to default.
     BankAccount? effectiveBank;
-    final showBankDetails = await SettingsService.getShowBankDetails();
-    if (showBankDetails) {
-      final bankAccounts = await SettingsService.getBankAccounts();
+    if (s.showBankDetails) {
       final savedId = invoice.bankAccountId;
       if (savedId != null && savedId.isNotEmpty) {
-        effectiveBank = bankAccounts
-            .where((e) => e.accountNumber == savedId)
-            .firstOrNull;
+        effectiveBank = s.bankAccounts.where((e) => e.accountNumber == savedId).firstOrNull;
       }
-      effectiveBank ??= bankAccounts.where((e) => e.isDefault).firstOrNull
-          ?? bankAccounts.firstOrNull;
+      effectiveBank ??= s.bankAccounts.where((e) => e.isDefault).firstOrNull
+          ?? s.bankAccounts.firstOrNull;
     }
 
-    switch (selectedTemplate) {
+    switch (s.template) {
       case InvoiceTemplate.classic:
-        pdf.addPage(await _buildClassicTemplate(
-          invoice, company, currencySymbol, invoicePrefix,
-          upiId: effectiveUpiId, showUpiQr: showUpiQr, showGst: showGst,
-          showQuantity: showQuantity, showDiscount: showDiscount, showTypeTag: showTypeTag, businessType: businessType,
-          bankAccount: effectiveBank, datePattern: datePattern,
+        pdf.addPage(_buildClassicTemplate(
+          invoice, s.company, currencySymbol, s.invoicePrefix,
+          upiId: effectiveUpiId, showUpiQr: showUpiQr, showGst: s.showGst,
+          showQuantity: s.showQuantity, showDiscount: s.showDiscount,
+          showTypeTag: s.showTypeTag, businessType: s.businessType,
+          bankAccount: effectiveBank, datePattern: s.datePattern,
+          logoPosition: s.logoPosition, logoSizePx: s.logoSizePx,
+          logoBytes: s.logoBytes, thankYouNote: s.thankYouNote,
         ));
-        break;
       case InvoiceTemplate.modern:
-        pdf.addPage(await _buildModernTemplate(
-          invoice, company, currencySymbol, invoicePrefix,
-          upiId: effectiveUpiId, showUpiQr: showUpiQr, showGst: showGst,
-          showQuantity: showQuantity, showDiscount: showDiscount, showTypeTag: showTypeTag, businessType: businessType,
-          bankAccount: effectiveBank, datePattern: datePattern,
+        pdf.addPage(_buildModernTemplate(
+          invoice, s.company, currencySymbol, s.invoicePrefix,
+          upiId: effectiveUpiId, showUpiQr: showUpiQr, showGst: s.showGst,
+          showQuantity: s.showQuantity, showDiscount: s.showDiscount,
+          showTypeTag: s.showTypeTag, businessType: s.businessType,
+          bankAccount: effectiveBank, datePattern: s.datePattern,
+          logoPosition: s.logoPosition, logoSizePx: s.logoSizePx,
+          logoBytes: s.logoBytes, thankYouNote: s.thankYouNote,
         ));
-        break;
       case InvoiceTemplate.minimal:
-        pdf.addPage(await _buildMinimalTemplate(
-          invoice, company, currencySymbol, invoicePrefix,
-          upiId: effectiveUpiId, showUpiQr: showUpiQr, showGst: showGst,
-          showQuantity: showQuantity, showDiscount: showDiscount, showTypeTag: showTypeTag, businessType: businessType,
-          bankAccount: effectiveBank, datePattern: datePattern,
+        pdf.addPage(_buildMinimalTemplate(
+          invoice, s.company, currencySymbol, s.invoicePrefix,
+          upiId: effectiveUpiId, showUpiQr: showUpiQr, showGst: s.showGst,
+          showQuantity: s.showQuantity, showDiscount: s.showDiscount,
+          showTypeTag: s.showTypeTag, businessType: s.businessType,
+          bankAccount: effectiveBank, datePattern: s.datePattern,
+          logoPosition: s.logoPosition, logoSizePx: s.logoSizePx,
+          logoBytes: s.logoBytes, thankYouNote: s.thankYouNote,
         ));
-        break;
     }
-
     return pdf;
   }
 
-  static Future<pw.MultiPage> _buildClassicTemplate(
+  static Future<pw.Document> generateInvoicePDF(Invoice invoice, {String datePattern = 'dd/MM/yyyy'}) async {
+    final settings = await fetchPdfSettings(datePattern: datePattern);
+    return generateInvoicePDFWithSettings(invoice, settings);
+  }
+
+  static pw.MultiPage _buildClassicTemplate(
     Invoice invoice, CompanyInfo? company, String currencySymbol, String invoicePrefix, {
     String? upiId, bool showUpiQr = false, bool showGst = true,
     bool showQuantity = true, bool showDiscount = true, bool showTypeTag = true, BusinessType businessType = BusinessType.both,
     BankAccount? bankAccount, String datePattern = 'dd/MM/yyyy',
-  }) async
+    LogoPosition logoPosition = LogoPosition.left, double logoSizePx = 90,
+    Uint8List? logoBytes, String thankYouNote = '',
+  })
   {
-    final accentColor = PdfColors.indigo900; // Use a strong accent color
-    final LogoPosition logoPosition = await SettingsService.getLogoPosition();
-    final logoSizePx = _logoSizePx(await SettingsService.getLogoSize());
-    final base64Logo = await SettingsService.getCompanyLogo();
-    final logoImage = base64Logo != null ? pw.MemoryImage(base64Decode(base64Logo)) : null;
-    final String thankyouNote = await SettingsService.getSetting(SettingKey.thankYouNote) ?? DefaultValues.thankYouNote;
+    final accentColor = PdfColors.indigo900;
+    final logoImage = logoBytes != null ? pw.MemoryImage(logoBytes) : null;
+    final thankyouNote = thankYouNote;
 
     return pw.MultiPage(
       pageFormat: PdfPageFormat.a4,
@@ -258,19 +363,18 @@ class PDFService {
     );
   }
 
-  static Future<pw.MultiPage> _buildMinimalTemplate(
+  static pw.MultiPage _buildMinimalTemplate(
     Invoice invoice, CompanyInfo? company, String currencySymbol, String invoicePrefix, {
     String? upiId, bool showUpiQr = false, bool showGst = true,
     bool showQuantity = true, bool showDiscount = true, bool showTypeTag = true, BusinessType businessType = BusinessType.both,
     BankAccount? bankAccount, String datePattern = 'dd/MM/yyyy',
-  }) async
+    LogoPosition logoPosition = LogoPosition.left, double logoSizePx = 90,
+    Uint8List? logoBytes, String thankYouNote = '',
+  })
   {
-    final accentColor = PdfColors.grey700; // Use a strong, neutral accent
-    final LogoPosition logoPosition = await SettingsService.getLogoPosition();
-    final logoSizePx = _logoSizePx(await SettingsService.getLogoSize());
-    final base64Logo = await SettingsService.getCompanyLogo();
-    final logoImage = base64Logo != null ? pw.MemoryImage(base64Decode(base64Logo)) : null;
-    final String thankyouNote = await SettingsService.getSetting(SettingKey.thankYouNote) ?? "";
+    final accentColor = PdfColors.grey700;
+    final logoImage = logoBytes != null ? pw.MemoryImage(logoBytes) : null;
+    final thankyouNote = thankYouNote;
 
     return pw.MultiPage(
       pageFormat: PdfPageFormat.a4,
@@ -407,19 +511,18 @@ class PDFService {
     );
   }
 
-  static Future<pw.MultiPage> _buildModernTemplate(
+    static pw.MultiPage _buildModernTemplate(
     Invoice invoice, CompanyInfo? company, String currencySymbol, String invoicePrefix, {
     String? upiId, bool showUpiQr = false, bool showGst = true,
     bool showQuantity = true, bool showDiscount = true, bool showTypeTag = true, BusinessType businessType = BusinessType.both,
     BankAccount? bankAccount, String datePattern = 'dd/MM/yyyy',
-  }) async
+    LogoPosition logoPosition = LogoPosition.left, double logoSizePx = 90,
+    Uint8List? logoBytes, String thankYouNote = '',
+  })
   {
     final accentColor = PdfColors.blue600;
-    final LogoPosition logoPosition = await SettingsService.getLogoPosition();
-    final logoSizePx = _logoSizePx(await SettingsService.getLogoSize());
-    final base64Logo = await SettingsService.getCompanyLogo();
-    final logoImage = base64Logo != null ? pw.MemoryImage(base64Decode(base64Logo)) : null;
-    final String thankyouNote = await SettingsService.getSetting(SettingKey.thankYouNote) ?? "";
+    final logoImage = logoBytes != null ? pw.MemoryImage(logoBytes) : null;
+    final thankyouNote = thankYouNote;
 
     return pw.MultiPage(
       pageFormat: PdfPageFormat.a4,
@@ -821,7 +924,7 @@ class PDFService {
     final isPaidInFull = invoice.outstandingBalance <= 0;
 
     return pw.Container(
-      width: 250,
+      width: 200,
       decoration: pw.BoxDecoration(
         border: pw.Border.all(color: PdfColors.grey300),
         borderRadius: pw.BorderRadius.circular(6),
@@ -1075,8 +1178,8 @@ class PDFService {
       builder: (dialogContext) => Dialog(
         insetPadding: const EdgeInsets.all(16),
         child: SizedBox(
-          width: MediaQuery.sizeOf(dialogContext).width * 0.75,
-          height: MediaQuery.sizeOf(dialogContext).height * 0.8,
+          width: (MediaQuery.sizeOf(dialogContext).width * 0.8).clamp(300.0, AppLayout.maxWidthNarrow),
+          height: (MediaQuery.sizeOf(dialogContext).height * 0.9).clamp(400.0, 1000.0),
           child: Column(
             children: [
               AppBar(
@@ -1103,7 +1206,12 @@ class PDFService {
                 ],
               ),
               Expanded(
-                child: SfPdfViewer.memory(pdfBytes),
+                child: SfPdfViewer.memory(
+                  pdfBytes,
+                  pageLayoutMode: PdfPageLayoutMode.continuous,
+                  canShowPageLoadingIndicator: false,
+                  canShowScrollStatus: false,
+                ),
               ),
             ],
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: invoiso
 description: "Invoice generating desktop app built with Flutter"
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 4.1.3
+version: 4.1.4
 environment:
   sdk: '>=3.3.3 <4.0.0'
 


### PR DESCRIPTION
Bulk mark as paid, filtered PDF download, PDF preview perf, discount fix

  Features:
  - Bulk "Mark as Paid" — single DB transaction for N invoices (PaymentService.addPaymentBatch)
  - Filtered bulk PDF download — by date range or invoice number range, hard cap 100 PDFs
  - Streaming ZIP export — one PDF in RAM at a time (OutputFileStream), no full archive in memory
  - PdfGenerationSettings — settings fetched once per batch (was 16 DB reads × N invoices)

  Performance:
  - PDF generation: 14+ sequential DB reads → single Future.wait (parallel batch)
  - Logo bytes cache — base64 decoded once, reused on repeat preview opens
  - Template builders now sync (no internal SettingsService calls)
  - SfPdfViewer: continuous layout, hide page loading indicator and scroll status
  - PDF preview dialog: max width 900px / height 1000px (AppLayout.maxWidthNarrow)
  - countInvoicesForExport — lightweight COUNT(*) query, no object construction

  Fixes:
  - PDF discount column showed per-unit value (₹50) instead of line total (₹100) when discountPerUnit=true
  - Additional notes and totals now side-by-side row across all 3 PDF templates

  Other:
  - getInvoicesForExport extended with fromId/toId invoice number range filter